### PR TITLE
Mute local video to prevent feedback loop

### DIFF
--- a/electron-app/src/dssclient.ts
+++ b/electron-app/src/dssclient.ts
@@ -42,6 +42,7 @@ const btnPollOffers = (<HTMLButtonElement>window.document.getElementById("pollOf
 const btnCreateOffer = (<HTMLButtonElement>window.document.getElementById("createOffer"));
 
 const localVideo = (<HTMLMediaElement>window.document.getElementById("localVideo"));
+localVideo.muted;
 const remoteVideo = (<HTMLMediaElement>window.document.getElementById("remoteVideo"));
 var remoteVideoSource: MediaStream;
 // TODO remove these two variables below


### PR DESCRIPTION
Electron app was playing the audio from local capture, creating an annoying feedback loop. This simply mutes it.